### PR TITLE
Add (provisional) schedule.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -379,10 +379,45 @@ section h1:before {
     background-position: 40px 65px;
     background-image: url(../img/info_icon4.png);
 }
+
 .schedule {
-    background-position: 50px 65px;
-    background-image: url(../img/info_icon2.png);
+    font-size: 10px;
+    background: #40312e;
 }
+
+.schedule td ,
+.schedule th {
+    padding: 3px 5px;
+}
+
+.schedule thead th {
+
+    text-transform: uppercase;
+    border-bottom: 3px solid #fff;
+}
+
+.schedule tbody th {
+    background: #372D2C;
+    border-bottom: 1px solid #fff;
+}
+
+.schedule tr.wide td {
+    text-align: center;
+}
+
+.schedule tbody td {
+    border-bottom: 1px solid #fff;
+}
+
+.schedule tbody tr.last td ,
+.schedule tbody tr.last th {
+    border: none;
+}
+
+.schedule tfoot td {
+    border-top: 3px solid #fff;
+}
+
 .what-is {
     background-position: 50px 65px;
     background-image: url(../img/info_icon1.png);

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
           <ul>
             <li><a href="#home">Home</a></li>
             <li><a href="#information">Information</a></li>
-            <li><a href="#speakers">Speakers</a></li>
+            <li><a href="#speakers">Speakers / Schedule</a></li>
             <li><a href="#sponsors">Sponsors</a></li>
             <li><a href="#tickets">Tickets / Contacts</a></li>
           </ul>
@@ -105,30 +105,6 @@
         </div>
 
         <div class="item">
-          <h2>Check Out the Full Event Schedule</h2>
-          <div class="inner schedule">
-            <p>Spread over two days, Whisky Web will combine a more traditional
-            two-track programme of talks the first day, with a
-            <em>hackathon</em> event on day two.  But the fun doesn't begin
-            there; the evening before the conference the organisers would like
-            to invite the delegates to join them in Edinburgh's Brewdog bar for
-            an informal opportunity to become better acquainted.</p>
-
-            <p>The first day will open with our delegates being treated to a
-            warm Scottish welcome as they are played into the venue by a
-            traditional bagpiper.  There will be the usual opportunity to grab
-            a coffee and a chat before we begin with the first keynote and the
-            talks get underway.  As the evening draws in, the lovely folk from
-            Bruichladdich will give a masterclass on Scotch Whisky to get the
-            party started!</p>
-
-            <p>Day two will see delegates rolling their sleeves up and getting
-            their hands dirty in our hackathon event.</p>
-
-            </div>
-        </div>
-
-        <div class="item">
           <h2>Bruichladdich Islay Single Malt – Scotch Whisky Masterclass</h2>
           <div class="inner whisky-guide">
               <p> Bruichladdich teams up with Whisky Web to deliver an overview of
@@ -167,7 +143,7 @@
 
     <section id="speakers" class="speakers-section">
       <div>
-      <h1>Speakers</h1>
+      <h1>Speakers / Schedule</h1>
       
       <ul id="keynotes">
         <li>
@@ -304,7 +280,70 @@ Thijs is also boardmember of the PHPBenelux user group and organized thePHPBenel
         </li>
       </ul>
       
-      <h2 id="announce">Schedule coming soon... Stay Tuned</h2>
+      <h2 id="announce">Schedule</h2>
+      <table class="schedule" width="100%" cellpadding="0" cellspacing="0">
+        <thead>
+          <tr>
+            <th>&nbsp;</td>
+            <th>Track 1</th>
+            <th>Track 2</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="wide">
+            <th><time datetime="2012-04-13T08:30:00Z">08:30</time> &ndash; <time datetime="2012-04-13T08:45:00Z">08:45</time></th>
+            <td colspan="2"><p>Arrival & Registration</p></td>
+          </tr>
+          <tr class="wide">
+            <th><time datetime="2012-04-13T08:45:00Z">08:45</time> &ndash; <time datetime="2012-04-13T09:00:00Z">09:00</time></th>
+            <td colspan="2"><p>Opening Remarks - Juozas "Joe" Kaziukėnas</p></td>
+          </tr>
+          <tr class="wide">
+            <th><time datetime="2012-04-13T09:00:00Z">09:00</time> &ndash; <time datetime="2012-04-13T10:00:00Z">10:00</time></th>
+            <td colspan="2"><p>Keynote: Josh Holmes</p></td>
+          </tr>
+          <tr>
+            <th><time datetime="2012-04-13T10:00:00:Z">10:00</time> - <time datetime="2012-04-13T11:15:00Z">11:15</time></th>
+            <td><p>OpenStreetMap For The Web &ndash; Derick Rethans</p><p class="talk-summary"></p></td>
+            <td><p>The Emperor's New Clothes &ndash; Kevinjohn Gallagher</p><p class="talk-summary"></p></td>
+          </tr>
+          <tr>
+            <th><time datetime="2012-04-13T11:15:00:Z">11:15</time> - <time datetime="2012-04-13T12:30:00Z">12:30</time></th>
+            <td><p>Mashing Up JavaScript &ndash; Bastian Hofmann</p><p class="talk-summary"></p></td>
+            <td><p>Essential Node.js For Web Developers &ndash; Mike Amundsen</p><p class="talk-summary"></p></td>
+          </tr>
+          <tr>
+            <th><time datetime="2012-04-13T12:30:00:Z">12:30</time> - <time datetime="2012-04-13T13:30:00Z">13:30</time></th>
+            <td colspan="2"><p>Lunch</p></td>
+          </tr>
+          <tr>
+            <th><time datetime="2012-04-13T13:30:00:Z">13:30</time> - <time datetime="2012-04-13T14:45:00Z">14:45</time></th>
+            <td><p>Visualisng Data &ndash; Brian Suda</p><p class="talk-summary"></p></td>
+            <td><p>Estimation, or "How To Dig Your Own Grave" &ndash; Rowan Merewood</p><p class="talk-summary"></p></td>
+          </tr>
+          <tr>
+            <th><time datetime="2012-04-13T14:45:00:Z">14:45</time> - <time datetime="2012-04-13T16:00:00Z">16:00</time></th>
+            <td><p>Lessons Learned From Testing Legacy Code &ndash; John Mertic</p><p class="talk-summary"></p></td>
+            <td><p>Ten Commandments Of A Software Engineer &ndash; Sebastian Marek</p><p class="talk-summary"></p></td>
+          </tr>
+          <tr>
+            <th><time datetime="2012-04-13T16:00:00:Z">16:00</time> - <time datetime="2012-04-13T17:15:00Z">17:15</time></th>
+            <td><p>Alice & Bob: Public Key Cryptography 101 &ndash; Joshua Thijssen</p><p class="talk-summary"></p></td>
+            <td><p>Is Your App Ready For The (Hybrid) Cloud &ndash; Thijs Feryn</p><p class="talk-summary"></p></td>
+          </tr>
+          <tr class="wide">
+            <th><time datetime="2012-04-13T17:15:00Z">17:15</time> &ndash; <time datetime="2012-04-13T18:15:00Z">18:15</time></th>
+            <td colspan="2"><p>Keynote: David Zülke</p></td>
+          </tr>
+          <tr class="wide last">
+            <th><time datetime="2012-04-13T18:15:00Z">18:15</time> &ndash; <time datetime="2012-04-13T18:30:00Z">18:30</time></th>
+            <td colspan="2"><p>Closing Remarks - Juozas "Joe" Kaziukėnas</p></td>
+          </tr>
+        </tbody>
+        <tfoot>
+        <tr><td colspan="3"></td></tr>
+        </tfoot>
+      </table>
       </div>
     </section>
 


### PR DESCRIPTION
- Update 'Speakers' to 'Speakers / Schedule' in main navigation.
- Remove 'Check Out The Full Event Schedule' from Information section.
- Add schedule table.
